### PR TITLE
ci(coverage): expose `CC_TEST_REPORTER_ID`

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -73,6 +73,6 @@ jobs:
         uses: paambaati/codeclimate-action@v3.0.0
         if: ${{ matrix.target == 'test' && hashFiles('coverage/**/lcov.info') }}
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          CC_TEST_REPORTER_ID: 603d6113ce4313a4330ab7d1a08193545630d22cb6a7c18b658393bb56d95aa0
         with:
           coverageLocations: coverage/**/lcov.info:lcov


### PR DESCRIPTION
In [GitHub Action](https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow), secrets are only exposed on `push` from a branch of the same repo. It makes it impossible to publish a coverage report.

As stated in the [codeclimate documentation](https://docs.codeclimate.com/docs/finding-your-test-coverage-token#should-i-keep-my-test-reporter-id-secret) `CC_TEST_REPORTER_ID` can't be considered as a secret.