### PR TITLE
fix(runner): move non-host libraries to npm dependencies

### DIFF
--- a/packages/runner/project.json
+++ b/packages/runner/project.json
@@ -18,7 +18,8 @@
             "input": "",
             "output": ""
           }
-        ]
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies"
       }
     },
     "lint": {


### PR DESCRIPTION
closes #125