### PR TITLE
feat(scan): add test metadata support

### DIFF
--- a/packages/runner/src/lib/IssueFound.ts
+++ b/packages/runner/src/lib/IssueFound.ts
@@ -3,7 +3,10 @@ import { SecTesterError } from '@sectester/core';
 import { Issue } from '@sectester/scan';
 
 export class IssueFound extends SecTesterError {
-  constructor(public readonly issue: Issue, formatter: Formatter) {
+  constructor(
+    public readonly issue: Issue,
+    formatter: Formatter
+  ) {
     super(`Target is vulnerable\n\n${formatter.format(issue)}`);
   }
 }

--- a/packages/runner/src/lib/SecScanOptions.ts
+++ b/packages/runner/src/lib/SecScanOptions.ts
@@ -9,4 +9,5 @@ export type SecScanOptions = Pick<
   | 'skipStaticParams'
   | 'attackParamLocations'
   | 'starMetadata'
+  | 'testMetadata'
 >;

--- a/packages/scan/src/ScanFactory.ts
+++ b/packages/scan/src/ScanFactory.ts
@@ -43,8 +43,7 @@ export class ScanFactory {
     requestsRateLimit,
     skipStaticParams,
     attackParamLocations,
-    starMetadata,
-    testMetadata
+    starMetadata
   }: ScanSettings): Promise<ScanConfig> {
     const { id: entrypointId } = await this.discoveries.createEntrypoint(
       new Target(target),
@@ -58,7 +57,6 @@ export class ScanFactory {
       requestsRateLimit,
       skipStaticParams,
       starMetadata,
-      testMetadata,
       projectId: this.configuration.projectId,
       entryPointIds: [entrypointId],
       attackParamLocations: [...attackParamLocations],

--- a/packages/scan/src/ScanFactory.ts
+++ b/packages/scan/src/ScanFactory.ts
@@ -43,7 +43,8 @@ export class ScanFactory {
     requestsRateLimit,
     skipStaticParams,
     attackParamLocations,
-    starMetadata
+    starMetadata,
+    testMetadata
   }: ScanSettings): Promise<ScanConfig> {
     const { id: entrypointId } = await this.discoveries.createEntrypoint(
       new Target(target),
@@ -57,6 +58,7 @@ export class ScanFactory {
       requestsRateLimit,
       skipStaticParams,
       starMetadata,
+      testMetadata,
       projectId: this.configuration.projectId,
       entryPointIds: [entrypointId],
       attackParamLocations: [...attackParamLocations],

--- a/packages/scan/src/ScanSettings.spec.ts
+++ b/packages/scan/src/ScanSettings.spec.ts
@@ -187,5 +187,107 @@ describe('ScanSettings', () => {
         name: expect.stringMatching(/^.{1,199}…$/)
       });
     });
+
+    it('should handle broken access control test with string auth', () => {
+      // arrange
+      const testConfig = {
+        name: 'broken_access_control' as const,
+        options: {
+          auth: 'auth-object-id'
+        }
+      };
+      const settings: ScanSettingsOptions = {
+        tests: [testConfig],
+        target: { url: 'https://example.com' }
+      };
+
+      // act
+      const result = new ScanSettings(settings);
+
+      // assert
+      expect(result.tests).toEqual([testConfig]);
+    });
+
+    it('should handle broken access control test with tuple auth', () => {
+      // arrange
+      const testConfig = {
+        name: 'broken_access_control' as const,
+        options: {
+          auth: ['key', 'value'] as [string, string]
+        }
+      };
+      const settings: ScanSettingsOptions = {
+        tests: [testConfig],
+        target: { url: 'https://example.com' }
+      };
+
+      // act
+      const result = new ScanSettings(settings);
+
+      // assert
+      expect(result.tests).toEqual([testConfig]);
+    });
+
+    it('should deduplicate string tests', () => {
+      // arrange
+      const testName = 'xss';
+      const settings: ScanSettingsOptions = {
+        tests: [testName, testName],
+        target: { url: 'https://example.com' }
+      };
+
+      // act
+      const result = new ScanSettings(settings);
+
+      // assert
+      expect(result.tests).toEqual([testName]);
+    });
+
+    it('should not deduplicate object tests', () => {
+      // arrange
+      const testConfig1 = {
+        name: 'broken_access_control' as const,
+        options: {
+          auth: 'auth1'
+        }
+      };
+      const testConfig2 = {
+        name: 'broken_access_control' as const,
+        options: {
+          auth: 'auth2'
+        }
+      };
+      const settings: ScanSettingsOptions = {
+        tests: [testConfig1, testConfig2],
+        target: { url: 'https://example.com' }
+      };
+
+      // act
+      const result = new ScanSettings(settings);
+
+      // assert
+      expect(result.tests).toEqual([testConfig1, testConfig2]);
+    });
+
+    it('should handle mixed string and object tests', () => {
+      // arrange
+      const testName = 'xss';
+      const testConfig = {
+        name: 'broken_access_control' as const,
+        options: {
+          auth: 'auth-object-id'
+        }
+      };
+      const settings: ScanSettingsOptions = {
+        tests: [testName, testConfig],
+        target: { url: 'https://example.com' }
+      };
+
+      // act
+      const result = new ScanSettings(settings);
+
+      // assert
+      expect(result.tests).toEqual([testName, testConfig]);
+    });
   });
 });

--- a/packages/scan/src/ScanSettings.ts
+++ b/packages/scan/src/ScanSettings.ts
@@ -26,10 +26,15 @@ export interface ScanSettingsOptions {
    * @internal
    */
   starMetadata?: Record<string, unknown>;
+  /**
+   * Additional metadata for specific tests (e.g. broken access control).
+   */
+  testMetadata?: Record<string, unknown>;
 }
 
 export class ScanSettings implements ScanSettingsOptions {
   private _starMetadata?: Record<string, unknown>;
+  private _testMetadata?: Record<string, unknown>;
 
   get starMetadata(): Record<string, unknown> | undefined {
     return this._starMetadata;
@@ -37,6 +42,14 @@ export class ScanSettings implements ScanSettingsOptions {
 
   private set starMetadata(value: Record<string, unknown> | undefined) {
     this._starMetadata = value;
+  }
+
+  get testMetadata(): Record<string, unknown> | undefined {
+    return this._testMetadata;
+  }
+
+  private set testMetadata(value: Record<string, unknown> | undefined) {
+    this._testMetadata = value;
   }
 
   private _name!: string;
@@ -157,6 +170,7 @@ export class ScanSettings implements ScanSettingsOptions {
     repeaterId,
     smart = true,
     starMetadata,
+    testMetadata,
     requestsRateLimit = 0, // automatic rate limiting
     poolSize = 50, // up to 2x more than default pool size
     skipStaticParams = true,
@@ -173,6 +187,7 @@ export class ScanSettings implements ScanSettingsOptions {
     this.tests = tests;
     this.attackParamLocations = attackParamLocations;
     this.starMetadata = starMetadata;
+    this.testMetadata = testMetadata;
   }
 
   private resolveAttackParamLocations(

--- a/packages/scan/src/models/ScanConfig.ts
+++ b/packages/scan/src/models/ScanConfig.ts
@@ -1,10 +1,11 @@
 import { AttackParamLocation } from './AttackParamLocation';
+import { Test } from './Tests';
 
 export interface ScanConfig {
   name: string;
   projectId: string;
   entryPointIds: string[];
-  tests?: string[];
+  tests?: Test[];
   poolSize?: number;
   requestsRateLimit?: number;
   attackParamLocations?: AttackParamLocation[];
@@ -12,5 +13,4 @@ export interface ScanConfig {
   smart?: boolean;
   skipStaticParams?: boolean;
   starMetadata?: Record<string, unknown>;
-  testMetadata?: Record<string, unknown>;
 }

--- a/packages/scan/src/models/ScanConfig.ts
+++ b/packages/scan/src/models/ScanConfig.ts
@@ -12,4 +12,5 @@ export interface ScanConfig {
   smart?: boolean;
   skipStaticParams?: boolean;
   starMetadata?: Record<string, unknown>;
+  testMetadata?: Record<string, unknown>;
 }

--- a/packages/scan/src/models/Severity.spec.ts
+++ b/packages/scan/src/models/Severity.spec.ts
@@ -23,8 +23,8 @@ describe('Severity', () => {
           item.expected === 0
             ? 'zero'
             : item.expected > 0
-            ? 'positive'
-            : 'negative'
+              ? 'positive'
+              : 'negative'
       }))
     )(
       'should return $expectedLabel comparing $input.a and $input.b',

--- a/packages/scan/src/models/Tests.ts
+++ b/packages/scan/src/models/Tests.ts
@@ -1,0 +1,14 @@
+export type Test = string | BrokenAccessControlTest;
+
+export type BrokenAccessControlOptions =
+  | {
+      auth: string; // + anon
+    }
+  | {
+      auth: [string, string];
+    };
+
+export type BrokenAccessControlTest = {
+  name: 'broken_access_control';
+  options: BrokenAccessControlOptions;
+};

--- a/packages/scan/src/models/index.ts
+++ b/packages/scan/src/models/index.ts
@@ -6,3 +6,4 @@ export * from './IssueGroup';
 export * from './ScanState';
 export * from './ScanConfig';
 export * from './HttpMethod';
+export * from './Tests';


### PR DESCRIPTION
PR adds testMetadata field into sectester, which is required to run Broken Access Control test.

Format of metadata is based on existing data passing to backend on scan start:

```
    "tests": ["broken_access_control"],
    "testMetadata": {
      "broken_access_control": {
        "authObjectId": [null, "xxxxx"]
      }
    },
```

Sectester serves as a proxy and does not impose any additional constraints on value formats. It follows the implementation described in https://github.com/NeuraLegion/sectester-js/pull/259
 as an example. Any format-related errors are expected to be reported by backend responses; therefore, no changes in Sectester are required if the format changes.


